### PR TITLE
Added all optional fields to all calls

### DIFF
--- a/lib/surveymonkey/SurveyMonkeyAPI_v2.js
+++ b/lib/surveymonkey/SurveyMonkeyAPI_v2.js
@@ -94,7 +94,17 @@ SurveyMonkeyAPI_v2.prototype.execute = function (resource, method, availablePara
 SurveyMonkeyAPI_v2.prototype.getRespondentList = function (params, callback) {
   if (typeof params === 'function') callback = params, params = {};
   this.execute('surveys', 'get_respondent_list', [
-      'survey_id'
+      'survey_id', 
+      'fields', 
+      'collector_id', 
+      'page', 
+      'page_size', 
+      'start_date', 
+      'end_date', 
+      'start_modified_date', 
+      'end_modified_date', 
+      'order asc', 
+      'order_by'
     ], params, callback);
 };
 
@@ -130,7 +140,16 @@ SurveyMonkeyAPI_v2.prototype.getSurveyDetails = function (params, callback) {
  */
 SurveyMonkeyAPI_v2.prototype.getSurveyList = function (params, callback) {
   if (typeof params === 'function') callback = params, params = {};
-  this.execute('surveys', 'get_survey_list', [], params, callback);
+  this.execute('surveys', 'get_survey_list', [
+      'page', 
+      'page_size', 
+      'start_date', 
+      'end_date',
+      'title',
+      'recipient_email',
+      'order_asc',
+      'fields'
+      ], params, callback);
 };
 
 /**
@@ -141,7 +160,14 @@ SurveyMonkeyAPI_v2.prototype.getSurveyList = function (params, callback) {
 SurveyMonkeyAPI_v2.prototype.getCollectorList = function (params, callback) {
   if (typeof params === 'function') callback = params, params = {};
   this.execute('surveys', 'get_collector_list', [
-      'survey_id'
+      'survey_id',
+      'page',
+      'page_size',
+      'start_date',
+      'end_date',
+      'name',
+      'order_asc',
+      'fields'
     ], params, callback);
 };
 


### PR DESCRIPTION
I needed to be able to specify fields for a few calls, and noticed that the library as it existed did not include the optional parameters.  This pull request simply uses the existing framework to allow the user to specify optional fields.
